### PR TITLE
Fixed res0 type in composingSemigroups test

### DIFF
--- a/src/main/scala/catslib/Semigroup.scala
+++ b/src/main/scala/catslib/Semigroup.scala
@@ -66,7 +66,7 @@ object SemigroupSection extends FlatSpec with Matchers with exercise.Section {
     * since the first version uses the Semigroup's `combine` operation, it will merge
     * the map's values with `combine`.
     */
-  def composingSemigroups(res0: Option[Map[String, Int]]) = {
+  def composingSemigroups(res0: Map[String, Int]) = {
     import cats.implicits._
 
     val aMap = Map("foo" → Map("bar" → 5))

--- a/src/test/scala/exercises/catslib/SemigroupSpec.scala
+++ b/src/test/scala/exercises/catslib/SemigroupSpec.scala
@@ -22,7 +22,7 @@ class SemigroupSpec extends Spec with Checkers {
     check(
       Test.testSuccess(
         SemigroupSection.composingSemigroups _,
-        Option(Map("bar" → 11)) :: HNil
+        Map("bar" → 11) :: HNil
       )
     )
   }


### PR DESCRIPTION
Hey @metasim, I've fixed the issue raised by @dialelo in your PR.  

https://github.com/scala-exercises/exercises-cats/pull/32